### PR TITLE
Translate README to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,51 @@
-## 経歴
+## Experience
 
-### 2025/2 ~ 2025/3 株式会社AbemaTV
-- 内定者アルバイト
-- AbemaTVへの配信広告案件管理プロダクトのバックエンド開発
-  - CDツールとして社内発OSSである[PipeCD](https://pipecd.dev/)を導入する。
-  - [TODO: テックブログURL添付]
+### Feb 2025 - Mar 2025: AbemaTV Inc.
+- Job Offer Intern
+- Backend development of a streaming advertisement project management product for AbemaTV
+  - Implemented PipeCD, an in-house developed OSS, as a CD tool
+  - [TODO: Attach tech blog URL]
 - GCP / Go / Kubernetes / Github Actions / PipeCD
 
-### 2024/12 ~ 2025/1 株式会社サイバーエージェント　AI事業本部 協業DXディビジョン
-- 内定者アルバイト
-- 大日本印刷と協業で開発しているエレベーターサイネージへの広告配信基盤のバックエンド開発
+### Dec 2024 - Jan 2025: CyberAgent Inc., AI Business HQ, Collaboration DX Division
+- Job Offer Intern
+- Backend development of an advertisement distribution platform for elevator signage in collaboration with Dai Nippon Printing
 - Rust / AWS
 
-### 2022/3  ~  2024/11 株式会社Catallaxy
-- 長期インターン
-- 未経験で入社、エンジニアとして就業する１社目の企業
+### Mar 2022 - Nov 2024: Catallaxy Inc.
+- Long-term Intern
+- First company as an engineer, joined with no prior experience
 - TypeScript / Next.js / Node.js / frourio / github actions / Docker / Cloud Run / Cloud SQL etc.
-- プロダクト機能開発
-  - 製造業向けマッチングプラットーフォーム
-  - 製造業向け案件管理サービス
-- 開発・運用体制改善
+- Product feature development
+  - Matching platform for manufacturing industry
+  - Project management service for manufacturing industry
+- Development and operation system improvement
   - CI/CD
-  - monitoring
-- マネジメント
-  - エンジニアインターン採用面接
-  - インターン生マネジメント
+  - Monitoring
+- Management
+  - Engineer intern recruitment interviews
+  - Intern management
 
 <a href="https://www.wantedly.com/companies/catallaxy/post_articles/893643">
   <img src="https://github.com/enomoto11/enomoto11/assets/102714865/6c24b343-415c-4c07-85b6-ef7c821ea1bf" height="170px"/>
 </a>
 
-### 2024/6   ~  2024/7 株式会社サイバーエージェント　AI事業本部 協業DXディビジョン
-- 内定者バイト
-- ANA X社との協業で開発している、広告配信基盤（DSP)のバックエンド開発
-- Go / AWS / dbt/ snowflake / Terraform
+### Jun 2024 - Jul 2024: CyberAgent Inc., AI Business HQ, Collaboration DX Division
+- Job Offer Intern
+- Backend development of an advertising distribution platform (DSP) in collaboration with ANA X
+- Go / AWS / dbt / snowflake / Terraform
 
-### 2023/2  ~  2023/10 株式会社メネルジア
-- 長期インターン
-- 株式会社Catallaxy に就業しながら兼業という形で参画した2社目の企業
+### Feb 2023 - Oct 2023: Menergia Inc.
+- Long-term Intern
+- Second company joined while working at Catallaxy Inc.
 - Go / lambda / RDS (MySQL) / TypeScript / Node.js
-- 医療学会員向け自社サービスのバックエンド開発
-  - 新規リソース作成、機能改修、パフォーマンスチューニング等
+- Backend development of in-house services for medical society members
+  - New resource creation, feature modifications, performance tuning, etc.
 
-### その他
-- 株式会社DeNA
-- フリー株式会社
-- 株式会社シロク
+### Others
+- DeNA Co., Ltd.
+- FREEE K.K.
+- SHIROKU Inc.
 
 <a href="https://developers.cyberagent.co.jp/blog/archives/47135">
   <img src="https://github.com/enomoto11/enomoto11/assets/102714865/21b2fb9d-2211-436a-b95a-1f797378a9d7" height="170px"/>


### PR DESCRIPTION
This PR translates the entire README content from Japanese to English.

The translation includes all sections:
- Experience timeline
- Company descriptions
- Project details
- Technical skills and tools
- Management experience

All the original layout and links have been maintained in the English version.

The goal is to make the profile accessible to English-speaking audiences while preserving all the original information.