### PR TITLE
Add Professional Interests Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
   <img src="https://github.com/enomoto11/enomoto11/assets/102714865/21b2fb9d-2211-436a-b95a-1f797378a9d7" height="170px"/>
 </a>
 
-## Professional Interests
+## Interests
 
 I'm passionate about building resilient, scalable, and observable systems. My core interests include:
 

--- a/README.md
+++ b/README.md
@@ -50,3 +50,33 @@
 <a href="https://developers.cyberagent.co.jp/blog/archives/47135">
   <img src="https://github.com/enomoto11/enomoto11/assets/102714865/21b2fb9d-2211-436a-b95a-1f797378a9d7" height="170px"/>
 </a>
+
+## Professional Interests
+
+I'm passionate about building resilient, scalable, and observable systems. My core interests include:
+
+### Site Reliability Engineering (SRE)
+- Creating resilient systems that scale and self-heal
+- Implementing SLOs/SLIs for reliable service measurement
+- Balancing reliability with innovation speed
+- Automating incident response and recovery processes
+
+### DevOps
+- Building CI/CD pipelines for seamless delivery
+- Infrastructure as Code (IaC) implementation
+- Automating repetitive operational tasks
+- Fostering collaboration between development and operations
+
+### Observability
+- Designing comprehensive monitoring systems
+- Creating actionable dashboards and alerts
+- Implementing distributed tracing in microservice architectures
+- Log aggregation and analysis for system insights
+
+### Infrastructure
+- Cloud-native architecture design
+- Container orchestration with Kubernetes
+- Serverless computing models
+- Network design and security implementation
+
+I believe in the power of automation and observability to create systems that are both resilient and delightful to maintain.


### PR DESCRIPTION
This PR adds a new "Professional Interests" section to the README, highlighting my expertise and passion in the following areas:

- **Site Reliability Engineering (SRE)**: Creating resilient systems, implementing SLOs/SLIs, and automating incident response
- **DevOps**: Building CI/CD pipelines, implementing Infrastructure as Code, and fostering collaboration
- **Observability**: Designing monitoring systems, implementing distributed tracing, and log analysis
- **Infrastructure**: Cloud-native architecture, Kubernetes, serverless computing, and network security

The additions maintain the same professional tone as the rest of the README and provide a clear overview of my technical focus areas.